### PR TITLE
Update CODEOWNERS: set initial set of maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # Codeowners for reviews on PRs.
 # Note: Anybody from org can help with review. In the end, at least one codeowner approval is required.
 
-*  @bretbrownjr @camio @dietmarkuehl @inbal2l @JeffGarland @neatudarius @steve-downey @bemanproject/core-reviewers
-
+*  @neatudarius @RaduNichita @mguludag @bemanproject/leads @bemanproject/core-reviewers


### PR DESCRIPTION
Update CODEOWNERS: set initial set of maintainers

Decided to have a small set of owners to start in order to speedup the website dev.