### PR TITLE
Add authors file

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -94,7 +94,7 @@ RaduNichita:
 
 steve-downey:
   name: Steve Downey
-  title: TODO
+  title: Software Engineer
   url: https://www.sdowney.org/
   image_url: https://avatars.githubusercontent.com/u/2809078?v=4
   page: true

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -33,6 +33,8 @@ dietmarkuehl:
   page: true
   socials:
     github: dietmarkuehl
+    stackoverflow: user:1120273
+    linkedin: dietmar-kühl
 
 ednolan:
   name: Eddie Nolan 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -27,7 +27,7 @@ dabrahams:
 
 dietmarkuehl:
   name: Dietmar Kühl 
-  title: TODO
+  title: Software Developer
   url: http://www.dietmar-kuehl.de/
   image_url: https://avatars.githubusercontent.com/u/1319703?v=4
   page: true

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -47,7 +47,7 @@ ednolan:
 
 inbal2l:
   name: Inbal Levi
-  title: C++ Enthusiast. ISO C++ Committee member.
+  title: Beman Lead, ISO C++ Library Evolution Chair.
   url: https://github.com/inbal2l
   image_url: https://avatars.githubusercontent.com/u/12187340?v=4
   page: true

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -107,3 +107,4 @@ wusatosi:
   page: true
   socials:
     github: wusatosi
+    linkedin: xueqing-wu-29a25724b

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -100,6 +100,8 @@ steve-downey:
   page: true
   socials:
     github: steve-downey
+    mastodon: @Sdowney@mastodon.social
+    bluesky: @sdowney.org
 
 wusatosi:
   name: River Wu

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -9,7 +9,7 @@ bretbrownjr:
 
 camio:
   name: David Sankel
-  title: C++ Developer, Beman Lead
+  title: Software Engineer, Beman Lead
   url: https://github.com/camio
   image_url: https://avatars.githubusercontent.com/u/3770603
   page: true

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -101,7 +101,7 @@ steve-downey:
 
 wusatosi:
   name: River Wu
-  title: Alumni of University of Michigan and routine contributor to Beman Project
+  title: Core contributor to the Beman Project, Alumni of University of Michigan.
   url: https://github.com/wusatosi
   image_url: https://avatars.githubusercontent.com/u/26424577?v=4
   page: true

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -23,7 +23,7 @@ dabrahams:
   image_url: https://avatars.githubusercontent.com/u/44065?v=4
   page: true
   socials:
-    github: dabrahams
+    github: camio
 
 dietmarkuehl:
   name: Dietmar Kühl 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,3 +1,12 @@
+bretbrownjr:
+  name: Bret Brown
+  title: Team Lead of the C++ Infrastructure team of the Developer Experience department at Bloomberg.
+  url: https://github.com/bretbrownjr
+  image_url: https://avatars.githubusercontent.com/u/2119138?v=4
+  page: true
+  socials:
+    github: bretbrownjr
+
 camio:
   name: David Sankel
   title: C++ Developer, Beman Lead
@@ -16,6 +25,33 @@ dabrahams:
   socials:
     github: dabrahams
 
+dietmarkuehl:
+  name: Dietmar Kühl 
+  title: TODO
+  url: http://www.dietmar-kuehl.de/
+  image_url: https://avatars.githubusercontent.com/u/1319703?v=4
+  page: true
+  socials:
+    github: dietmarkuehl
+
+ednolan:
+  name: Eddie Nolan 
+  title: C++ Developer
+  url: https://www.ednolan.com/
+  image_url: https://avatars.githubusercontent.com/u/907967?v=4
+  page: true
+  socials:
+    github: ednolan
+
+inbal2l:
+  name: Inbal Levi
+  title: C++ Enthusiast. ISO C++ Committee member.
+  url: https://github.com/inbal2l
+  image_url: https://avatars.githubusercontent.com/u/12187340?v=4
+  page: true
+  socials:
+    github: inbal2l
+
 JeffGarland:
   name: Jeff Garland
   title: Boost C++ Developer, C++ Committee Library Working Group Asst. Chair
@@ -24,3 +60,50 @@ JeffGarland:
   page: true
   socials:
     github: JeffGarland
+
+mguludag:
+  name: Muhammed Galib Uludağ 
+  title: SW Engineer (C++ CMake Linux Automotive)
+  url: https://github.com/mguludag
+  image_url: https://avatars.githubusercontent.com/u/12413639?v=4
+  page: true
+  socials:
+    github: mguludag
+
+neatudarius:
+  name: Darius Neațu
+  title: Software Engineer, C++ Committee member and PL researcher, Teaching Assistant
+  url: https://github.com/neatudarius
+  image_url: https://avatars.githubusercontent.com/u/8947836?v=4
+  page: true
+  socials:
+    github: neatudarius
+    linkedin: neatudarius
+
+RaduNichita:
+  name: Radu Nichita
+  title: Software Engineer and open source enthusiast
+  url: https://github.com/neatudarius
+  image_url: https://avatars.githubusercontent.com/u/45298861?v=4
+  page: true
+  socials:
+    github: RaduNichita
+    linkedin: radu-nichita
+
+steve-downey:
+  name: Steve Downey
+  title: TODO
+  url: https://www.sdowney.org/
+  image_url: https://avatars.githubusercontent.com/u/2809078?v=4
+  page: true
+  socials:
+    github: steve-downey
+
+wusatosi:
+  name: River Wu
+  title: Alumni of University of Michigan and routine contributor to Beman Project
+  url: https://github.com/wusatosi
+  image_url: https://avatars.githubusercontent.com/u/26424577?v=4
+  page: true
+  socials:
+    github: wusatosi

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -47,7 +47,7 @@ ednolan:
 
 inbal2l:
   name: Inbal Levi
-  title: Beman Lead, ISO C++ Library Evolution Chair.
+  title: Beman Lead, Software Engineer, ISO C++ Library Evolution Chair.
   url: https://github.com/inbal2l
   image_url: https://avatars.githubusercontent.com/u/12187340?v=4
   page: true
@@ -100,8 +100,8 @@ steve-downey:
   page: true
   socials:
     github: steve-downey
-    mastodon: @Sdowney@mastodon.social
-    bluesky: @sdowney.org
+    mastodon: Sdowney@mastodon.social
+    bluesky: sdowney.org
 
 wusatosi:
   name: River Wu

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -72,7 +72,7 @@ mguludag:
 
 neatudarius:
   name: Darius Neațu
-  title: Software Engineer, C++ Committee member and PL researcher, Teaching Assistant
+  title: Software Engineer, ISO C++ Committee Member, PL Researcher, Teaching Assistant
   url: https://github.com/neatudarius
   image_url: https://avatars.githubusercontent.com/u/8947836?v=4
   page: true


### PR DESCRIPTION
Adding the authors file for the website. I took the information from your Github profile. Order of authors is sorted alphabetically after the Github profile.

Feel free to add more of your social media accounts or modify the description as you want. You can push directly to the PR or comment here and I will apply the changes.

Closes: #62 

You can check a preview of how your profile would be rendered at https://deploy-preview-66--bemanproject.netlify.app/blog/authors/ (we won't publish this page, it's only for review purposes).
