### PR TITLE
Add sidebar label in the docs page sidebar.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+sidebar_label: Docs
 ---
 
 <!--
@@ -15,3 +16,4 @@ This directory contains information about how the project works, goals, and comm
 - [code_of_conduct.md](./code_of_conduct.md): The Beman Project's code of conduct.
 - [faq.md](./faq.md): Frequently asked questions about the Beman Project.
 - [governance.md](./governance.md): The governance document outlines the structure of the Beman Project.
+- [mission.md](./mission.md): The mission statement of the Beman Project.

--- a/docs/beman_library_maturity_model.md
+++ b/docs/beman_library_maturity_model.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+sidebar_label: Beman Library Maturity Model
 ---
 
 <!--

--- a/docs/beman_standard.md
+++ b/docs/beman_standard.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+sidebar_label: Beman Standard
 ---
 
 <!--

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+sidebar_label: Code of Conduct
 ---
 
 <!--

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+sidebar_label: FAQ
 ---
 
 <!--

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+sidebar_label: Governance
 ---
 
 <!--

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+sidebar_label: Mission
 ---
 
 <!--

--- a/scripts/sync-docs.py
+++ b/scripts/sync-docs.py
@@ -55,22 +55,29 @@ def copy_images(beman_repo_path: Path, website_repo_path: Path):
         shutil.copytree(beman_images_path, target_directory)
 
 
-def insert_sidebar_position(file_path: Path, sidebar_position: int):
+def insert_sidebar_metadata(file_path: Path, sidebar_position: int, sidebar_label: str):
     """
     Insert the sidebar position into the file.
-    Literally insert 3 lines at the top of the file:
+    Literally insert 3 (or 4) lines at the top of the file:
         ---
         sidebar_position: {sidebar_position}
+        sidebar_label: {sidebar_label}
         ---
     """
     with open(file_path, "r") as file:
         lines = file.readlines()
-    lines.insert(0, f"---\n")
-    lines.insert(1, f"sidebar_position: {sidebar_position}\n")
-    lines.insert(2, f"---\n")
-    lines.insert(3, f"\n")
+    prefix = [
+        f"---\n",
+        f"sidebar_position: {sidebar_position}\n",
+    ]
+    if sidebar_label:
+        prefix.append(f"sidebar_label: {sidebar_label}\n")
+    else:
+        raise ValueError(f"No side label provided for {file_path}")
+    prefix.append(f"---\n")
+    prefix.append(f"\n")
     with open(file_path, "w") as file:
-        file.writelines(lines)
+        file.writelines(prefix + lines)
 
 
 def sync_beman_docs(
@@ -78,6 +85,7 @@ def sync_beman_docs(
     website_repo_path: Path,
     relative_path: str,
     sidebar_position: int,
+    sidebar_label: str = "",
 ):
     """
     Copy beman/{relative_path} to /docs/{relative_path} for website build.
@@ -89,7 +97,7 @@ def sync_beman_docs(
     shutil.copy(beman_path, website_path)
 
     print(f"Inserting sidebar position {sidebar_position} into {website_path}")
-    insert_sidebar_position(website_path, sidebar_position)
+    insert_sidebar_metadata(website_path, sidebar_position, sidebar_label=sidebar_label)
 
 
 def main():
@@ -102,15 +110,51 @@ def main():
     website_repo_path = Path(__file__).parent.parent
 
     copy_images(beman_repo_path, website_repo_path)
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/README.md", 1)
     sync_beman_docs(
-        beman_repo_path, website_repo_path, "docs/beman_library_maturity_model.md", 2
+        beman_repo_path,
+        website_repo_path,
+        "docs/README.md",
+        1,
+        sidebar_label="Docs",
     )
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/beman_standard.md", 3)
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/mission.md", 4)
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/faq.md", 5)
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/governance.md", 6)
-    sync_beman_docs(beman_repo_path, website_repo_path, "docs/code_of_conduct.md", 7)
+    sync_beman_docs(
+        beman_repo_path,
+        website_repo_path,
+        "docs/beman_library_maturity_model.md",
+        2,
+        sidebar_label="Beman Library Maturity Model",
+    )
+    sync_beman_docs(
+        beman_repo_path,
+        website_repo_path,
+        "docs/beman_standard.md",
+        3,
+        sidebar_label="Beman Standard",
+    )
+    sync_beman_docs(
+        beman_repo_path,
+        website_repo_path,
+        "docs/mission.md",
+        4,
+        sidebar_label="Mission",
+    )
+    sync_beman_docs(
+        beman_repo_path, website_repo_path, "docs/faq.md", 5, sidebar_label="FAQ"
+    )
+    sync_beman_docs(
+        beman_repo_path,
+        website_repo_path,
+        "docs/governance.md",
+        6,
+        sidebar_label="Governance",
+    )
+    sync_beman_docs(
+        beman_repo_path,
+        website_repo_path,
+        "docs/code_of_conduct.md",
+        7,
+        sidebar_label="Code of Conduct",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Noticed the sidebar looked a bit simplistic, plus figured this is a good way to get familiar with the docs setup. As a bonus, the "Next" / "Prev" buttons' text also uses this new label field.

Attaching before and after images:

#### Before
<img width="337" height="386" alt="image" src="https://github.com/user-attachments/assets/9b1a9320-b8ec-479e-90a6-e6956cbc0e1e" />

#### After
<img width="339" height="398" alt="image" src="https://github.com/user-attachments/assets/5fe9a9a6-9dd1-45ec-8689-67b02be98c02" />
