### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/components/youtube-transformer.js
+++ b/src/components/youtube-transformer.js
@@ -1,12 +1,28 @@
 const YouTubeTransformer = {
   name: "YouTube",
   shouldTransform(url) {
-    return url.includes("youtube.com") || url.includes("youtu.be");
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname.toLowerCase();
+      const allowedHosts = [
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be"
+      ];
+      return allowedHosts.includes(hostname);
+    } catch (e) {
+      // If the URL cannot be parsed, it cannot be a valid YouTube URL.
+      return false;
+    }
   },
   getHTML(url) {
-    const videoId = url.includes("youtu.be")
-      ? url.split("/").pop()
-      : new URL(url).searchParams.get("v");
+    const urlObj = new URL(url);
+    const isShort = urlObj.hostname.toLowerCase() === "youtu.be" || urlObj.hostname.toLowerCase() === "www.youtu.be";
+    const videoId = isShort
+      ? urlObj.pathname.split("/").filter(Boolean).pop()
+      : urlObj.searchParams.get("v");
 
     return `
       <iframe


### PR DESCRIPTION
Potential fix for [https://github.com/bemanproject/website/security/code-scanning/1](https://github.com/bemanproject/website/security/code-scanning/1)

In general, to fix incomplete URL substring sanitization, you should parse the URL with a standard URL parser and then compare the `hostname` (or `host`) against an explicit set of allowed domains (and, if needed, their well‑defined subdomain patterns), instead of checking for substrings anywhere in the URL string.

For this specific code, the best fix without changing intended functionality is to (1) parse the `url` argument using the built‑in `URL` class, (2) inspect `hostname` to see whether it is one of the known YouTube hosts (`youtube.com`, `www.youtube.com`, `m.youtube.com`, `youtu.be`, etc.), and (3) only return `true` from `shouldTransform` when the hostname matches one of these allowed values. We should also ensure that `getHTML` derives the `videoId` based on the same hostname logic, so that it correctly handles both `youtube.com` and `youtu.be` URLs and is robust against malformed inputs. To avoid breaking behavior, we will preserve the existing embed generation but make the `shouldTransform` check more precise. Concretely, inside `src/components/youtube-transformer.js`, we will replace the substring logic in `shouldTransform` with a `try { new URL(url) } catch` block, extract `hostname`, and compare it against an `allowedHosts` array. We will also align the `youtu.be` check in `getHTML` to use parsed hostname (`urlObj.hostname === "youtu.be"`) rather than the previous naive `includes` check, ensuring consistency. No extra imports are needed as `URL` is part of the Node.js / browser standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
