### PR TITLE
Add hovertext and fix title of the Docs HTML pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 ---
+title: Docs
 sidebar_position: 1
 sidebar_label: Docs
 ---

--- a/docs/beman_library_maturity_model.md
+++ b/docs/beman_library_maturity_model.md
@@ -1,4 +1,5 @@
 ---
+title: Beman Library Maturity Model
 sidebar_position: 2
 sidebar_label: Beman Library Maturity Model
 ---

--- a/docs/beman_standard.md
+++ b/docs/beman_standard.md
@@ -1,4 +1,5 @@
 ---
+title: Beman Standard
 sidebar_position: 3
 sidebar_label: Beman Standard
 ---

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,4 +1,5 @@
 ---
+title: Code of Conduct
 sidebar_position: 7
 sidebar_label: Code of Conduct
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,5 @@
 ---
+title: FAQ
 sidebar_position: 5
 sidebar_label: FAQ
 ---

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,4 +1,5 @@
 ---
+title: Governance
 sidebar_position: 6
 sidebar_label: Governance
 ---

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -1,4 +1,5 @@
 ---
+title: Mission
 sidebar_position: 4
 sidebar_label: Mission
 ---

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -120,18 +120,21 @@ const config: Config = {
         { to: "/blog", label: "Blog", position: "left" },
         {
           "aria-label": "Discourse Forum",
+          title: "Discourse Forum",
           className: "navbar--discourse-link",
           href: "https://discourse.bemanproject.org/",
           position: "right",
         },
         {
           "aria-label": "Discord",
+          title: "Discord",
           className: "navbar--discord-link",
           href: "https://discord.com/invite/BKpNyJgSbm",
           position: "right",
         },
         {
           "aria-label": "GitHub Repository",
+          title: "GitHub",
           className: "navbar--github-link",
           href: "https://github.com/bemanproject",
           position: "right",

--- a/scripts/sync-docs.py
+++ b/scripts/sync-docs.py
@@ -68,6 +68,7 @@ def insert_sidebar_metadata(file_path: Path, sidebar_position: int, sidebar_labe
         lines = file.readlines()
     prefix = [
         "---\n",
+        f"title: {sidebar_label}\n",
         f"sidebar_position: {sidebar_position}\n",
     ]
     if sidebar_label:


### PR DESCRIPTION
This small PR updates two small aspects of the website that seemed slightly off to me.
- Now the discourse and discord icons have hovertext, for cases where a user may not know what those logos are
- The HTML page titles of all the docs pages are now named properly (earlier, the page title was the snake-case name of the file).
Old image:
<img width="412" height="227" alt="image" src="https://github.com/user-attachments/assets/fd1df0c5-f25c-4b7c-b6da-065d38763a30" />
New image
<img width="323" height="228" alt="image" src="https://github.com/user-attachments/assets/59abd882-84e6-46d3-85c4-aa5d3d4598fd" />

Very minor quick fix so hopefully easy to approve after netlifly.