### PR TITLE
Exclude synced docs and assets from pre-commit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "extends": ["eslint:recommended"],
+  "ignorePatterns": ["build/", "node_modules/", ".docusaurus/", "static/"]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,4 @@ repos:
     hooks:
       - id: gitleaks
 
-exclude: |
-  ^static/.*
-  ^node_modules/.*
+exclude: ^(?:static/|node_modules/|docs/|images/)

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -51,8 +51,8 @@ const FeatureList: FeatureItem[] = [
       <>
         Submission into the Beman Project is easy – start a discussion on our{" "}
         <a href="https://discourse.bemanproject.org/">discourse</a> or{" "}
-        <a href="https://discord.com/invite/BKpNyJgSbm">Discord</a> and the
-        the welcome team will help get you started. A general precondition is an
+        <a href="https://discord.com/invite/BKpNyJgSbm">Discord</a> and the the
+        welcome team will help get you started. A general precondition is an
         intent to submit a library for standardization. If you don’t have
         repository yet, or you want to upgrade to our standard we can help. Once
         your library is ready and has a paper, we’ll include it in{" "}


### PR DESCRIPTION
## Summary
- Exclude `docs/`, `images/`, `static/`, and `node_modules/` from pre-commit via a single regex (multiline patterns never matched)
- Matches Trunk ignore rules for auto-synced docs and binary assets
- Adds minimal `.eslintrc.json` so the eslint hook can run on `src/` files

## Motivation
Push pre-commit checks fail on synced docs and SVG assets that Trunk already skips. This keeps lint focused on website-owned source.

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [ ] `pre-commit / Pre-Commit check on Push` is green in CI

