### PR TITLE
Fix CodeQL alert #1: YouTube URL hostname validation

### DIFF
--- a/src/components/youtube-transformer.js
+++ b/src/components/youtube-transformer.js
@@ -1,12 +1,30 @@
 const YouTubeTransformer = {
   name: "YouTube",
   shouldTransform(url) {
-    return url.includes("youtube.com") || url.includes("youtu.be");
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname.toLowerCase();
+      const allowedHosts = [
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+      ];
+      return allowedHosts.includes(hostname);
+    } catch (e) {
+      // If the URL cannot be parsed, it cannot be a valid YouTube URL.
+      return false;
+    }
   },
   getHTML(url) {
-    const videoId = url.includes("youtu.be")
-      ? url.split("/").pop()
-      : new URL(url).searchParams.get("v");
+    const urlObj = new URL(url);
+    const isShort =
+      urlObj.hostname.toLowerCase() === "youtu.be" ||
+      urlObj.hostname.toLowerCase() === "www.youtu.be";
+    const videoId = isShort
+      ? urlObj.pathname.split("/").filter(Boolean).pop()
+      : urlObj.searchParams.get("v");
 
     return `
       <iframe


### PR DESCRIPTION
## Summary
- Replace `url.includes("youtube.com")` / `url.includes("youtu.be")` with hostname allowlist parsing via the `URL` API
- Align `getHTML` with the same hostname logic for youtu.be vs youtube.com URLs

Fixes [code scanning alert #1](https://github.com/bemanproject/website/security/code-scanning/1) (`js/incomplete-url-substring-sanitization`).

Replaces closed #177 with a single-file change on current `main`.

## Test plan
- [ ] CodeQL check passes on PR
- [ ] YouTube embeds still work for `youtube.com/watch?v=…` and `youtu.be/…` links in blog/docs

Made with [Cursor](https://cursor.com)