### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import clsx from "clsx";
-import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";


### PR DESCRIPTION
To fix this, remove the unused `Link` import from `src/pages/index.tsx`.

Best single fix (no functional change):
- Edit the import section at the top of `src/pages/index.tsx`.
- Delete the line:
  - `import Link from "@docusaurus/Link";`
- No additional methods, definitions, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._